### PR TITLE
feat: お問い合わせページを追加 (#145)

### DIFF
--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import { Routes, Route, Navigate } from 'react-router'
 import { MainPage } from './pages/MainPage'
 import { LoginPage } from './pages/LoginPage'
 import { SignupPage } from './pages/SignupPage'
+import { ContactPage } from './pages/ContactPage'
 
 function App() {
   return (
@@ -9,6 +10,7 @@ function App() {
       <Route path="/" element={<MainPage />} />
       <Route path="/login" element={<LoginPage />} />
       <Route path="/signup" element={<SignupPage/>} />
+      <Route path="/contact" element={<ContactPage />} />
       <Route path="*" element={<Navigate to="/" replace />} />
     </Routes>
   )

--- a/apps/frontend/src/components/layout/Sidebar.tsx
+++ b/apps/frontend/src/components/layout/Sidebar.tsx
@@ -1,6 +1,7 @@
-import { X, Sun, Moon, User, Settings } from 'lucide-react'
+import { X, Sun, Moon, User, Settings, HelpCircle, Mail } from 'lucide-react'
 // 実装後に有効化
 // import { Save, FolderOpen, LayoutGrid, Flame } from 'lucide-react'
+import { useNavigate } from 'react-router'
 import { useUIStore } from '@/stores/useUIStore'
 import { useThemeStore } from '@/stores/useThemeStore'
 
@@ -9,6 +10,7 @@ export function Sidebar() {
   const closeSidebar = useUIStore(s => s.closeSidebar)
   const theme = useThemeStore(s => s.theme)
   const toggleTheme = useThemeStore(s => s.toggleTheme)
+  const navigate = useNavigate()
   // 実装後に有効化
   // const [excitementDetection, setExcitementDetection] = useState(false)
 
@@ -81,6 +83,14 @@ export function Sidebar() {
             <MenuItem onClick={toggleTheme}>
               {theme === 'dark' ? <Sun className="w-4 h-4" /> : <Moon className="w-4 h-4" />}
               {theme === 'dark' ? 'ライトモード' : 'ダークモード'}
+            </MenuItem>
+          </MenuSection>
+
+          {/* サポート */}
+          <MenuSection title="サポート" icon={<HelpCircle className="w-4 h-4" />}>
+            <MenuItem onClick={() => { onClose(); navigate('/contact') }}>
+              <Mail className="w-4 h-4" />
+              お問い合わせ
             </MenuItem>
           </MenuSection>
         </nav>

--- a/apps/frontend/src/pages/ContactPage.tsx
+++ b/apps/frontend/src/pages/ContactPage.tsx
@@ -1,0 +1,42 @@
+import { Link } from 'react-router'
+import { ArrowLeft } from 'lucide-react'
+
+export function ContactPage() {
+  return (
+    <div className="min-h-screen bg-apple-bg text-apple-text-primary dark:bg-apple-dark-bg dark:text-apple-dark-text-primary">
+      <div className="max-w-3xl mx-auto px-4 py-8">
+        <div className="mb-6">
+          <Link
+            to="/"
+            className="inline-flex items-center gap-1 text-sm text-apple-text-secondary hover:text-apple-text-primary dark:text-apple-dark-text-secondary dark:hover:text-white"
+          >
+            <ArrowLeft className="w-4 h-4" />
+            メイン画面に戻る
+          </Link>
+        </div>
+
+        <div className="bg-apple-card border border-apple-border dark:bg-apple-dark-card dark:border-apple-dark-border rounded-2xl shadow-apple-lg p-6 sm:p-8">
+          <h1 className="text-2xl font-bold mb-2">お問い合わせ</h1>
+          <p className="text-sm text-apple-text-secondary dark:text-apple-dark-text-secondary mb-6">
+            バグ報告・機能要望・その他のご意見をお寄せください。
+          </p>
+
+          <div className="w-full overflow-hidden rounded-lg">
+            <iframe
+              src="https://docs.google.com/forms/d/e/1FAIpQLSei9OZtnwopsLlnxAy8V85LTHCx1AC4KHJJDj5Yh4e5nTmovg/viewform?embedded=true"
+              width="100%"
+              height="933"
+              frameBorder="0"
+              marginHeight={0}
+              marginWidth={0}
+              title="お問い合わせフォーム"
+              className="w-full"
+            >
+              読み込んでいます…
+            </iframe>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## 概要
ユーザーからのフィードバック・バグ報告・機能要望を受け付けるお問い合わせ機能を実装しました。

closes #145

## 実装内容
- `ContactPage.tsx` を新規作成
- Google Formsをiframeで埋め込み
- `/contact` ルートを追加
- サイドバーに「サポート」セクションを追加し、お問い合わせメニューから遷移できるように

## 実装方針
要件定義で検討した4案のうち、**Google Forms埋め込み（案1）** で実装。
- バックエンド不要ですぐに運用開始できる
- 回答はGoogle Formsで一元管理

## 動作確認
- [x] `/contact` ページでフォームが表示される
- [x] サイドバー → サポート → お問い合わせで遷移できる
- [x] フォームから送信できる
- [x] ダークモード対応
- [x] TypeScript型チェック通過
- [x] ESLint通過

## スクリーンショット
ページタイトル「お問い合わせ」+ Googleフォームの埋め込みで表示。
送信後はGoogleフォームの完了画面が表示される。