### PR TITLE
feat: タイルリサイズ機能を追加 (#61)

### DIFF
--- a/apps/frontend/src/components/DraggableTile.test.tsx
+++ b/apps/frontend/src/components/DraggableTile.test.tsx
@@ -11,6 +11,8 @@ describe('DraggableTile', () => {
     embedUrl: 'https://www.youtube.com/embed/YIFDiECQUe8',
     x: 0,
     y: 0,
+    width: undefined as number | undefined,
+    height: undefined as number | undefined,
   }
 
   const renderDraggableTile = (stream = defaultStream) => {
@@ -44,5 +46,16 @@ describe('DraggableTile', () => {
   it('ドラッグハンドルが表示される', () => {
     renderDraggableTile()
     expect(screen.getByRole('button', { name: /ドラッグ/i })).toBeInTheDocument()
+  })
+
+  it('リサイズハンドルが表示される', () => {
+    renderDraggableTile()
+    expect(screen.getByRole('button', { name: /リサイズ/i })).toBeInTheDocument()
+  })
+
+  it('サイズがstyleで反映される', () => {
+    renderDraggableTile({ ...defaultStream, width: 800, height: 450 })
+    const tile = screen.getByRole('button', { name: /ドラッグ/i }).parentElement
+    expect(tile).toHaveStyle({ width: '800px', height: '450px' })
   })
 })

--- a/apps/frontend/src/components/DraggableTile.tsx
+++ b/apps/frontend/src/components/DraggableTile.tsx
@@ -1,5 +1,6 @@
+import { useState, useCallback } from 'react'
 import { useDraggable } from '@dnd-kit/core'
-import { GripVertical } from 'lucide-react'
+import { GripVertical, Maximize2 } from 'lucide-react'
 import { StreamTile } from '@/components/ui/StreamTile'
 import { useStreamStore } from '@/stores/useStreamStore'
 import type { Stream } from '@/stores/useStreamStore'
@@ -10,9 +11,37 @@ type DraggableTileProps = {
 
 export function DraggableTile({ stream }: DraggableTileProps) {
   const removeStream = useStreamStore(s => s.removeStream)
+  const updateStreamSize = useStreamStore(s => s.updateStreamSize)
+  const [isResizing, setIsResizing] = useState(false)
   const { attributes, listeners, setNodeRef, transform, isDragging } = useDraggable({
     id: stream.id,
   })
+
+  const handleResizeStart = useCallback((e: React.MouseEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+    setIsResizing(true)
+
+    const startX = e.clientX
+    const startY = e.clientY
+    const startWidth = stream.width ?? 480
+    const startHeight = stream.height ?? 270
+
+    const handleMouseMove = (moveEvent: MouseEvent) => {
+      const deltaX = moveEvent.clientX - startX
+      const deltaY = moveEvent.clientY - startY
+      updateStreamSize(stream.id, startWidth + deltaX, startHeight + deltaY)
+    }
+
+    const handleMouseUp = () => {
+      setIsResizing(false)
+      document.removeEventListener('mousemove', handleMouseMove)
+      document.removeEventListener('mouseup', handleMouseUp)
+    }
+
+    document.addEventListener('mousemove', handleMouseMove)
+    document.addEventListener('mouseup', handleMouseUp)
+  }, [stream.id, stream.width, stream.height, updateStreamSize])
 
   const style: React.CSSProperties = {
     position: 'absolute',
@@ -38,8 +67,19 @@ export function DraggableTile({ stream }: DraggableTileProps) {
       <StreamTile
         stream={stream}
         onRemove={() => removeStream(stream.id)}
-        isDragging={isDragging}
+        isDragging={isDragging || isResizing}
       />
+
+      {/* リサイズハンドル */}
+      <div
+        role="button"
+        aria-label="リサイズ"
+        tabIndex={0}
+        onMouseDown={handleResizeStart}
+        className="absolute bottom-2 right-2 p-2.5 bg-black/60 hover:bg-black/80 rounded-full cursor-se-resize z-10 min-w-[44px] min-h-[44px] flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity duration-200"
+      >
+        <Maximize2 className="w-5 h-5 text-white" />
+      </div>
     </div>
   )
 }

--- a/apps/frontend/src/stores/useStreamStore.test.ts
+++ b/apps/frontend/src/stores/useStreamStore.test.ts
@@ -143,4 +143,49 @@ describe('useStreamStore', () => {
       expect(streams[1].x).toBe(expectedWidth + gap)
     })
   })
+
+  describe('updateStreamSize', () => {
+    it('ストリームのサイズを更新できる', () => {
+      useStreamStore.getState().addStream('https://www.youtube.com/watch?v=test1')
+      const streamId = useStreamStore.getState().streams[0].id
+
+      useStreamStore.getState().updateStreamSize(streamId, 800, 450)
+
+      const stream = useStreamStore.getState().streams[0]
+      expect(stream.width).toBe(800)
+      expect(stream.height).toBe(450)
+    })
+
+    it('最小サイズ以下にはならない（幅200px、高さ150px）', () => {
+      useStreamStore.getState().addStream('https://www.youtube.com/watch?v=test1')
+      const streamId = useStreamStore.getState().streams[0].id
+
+      useStreamStore.getState().updateStreamSize(streamId, 100, 50)
+
+      const stream = useStreamStore.getState().streams[0]
+      expect(stream.width).toBe(200)
+      expect(stream.height).toBe(150)
+    })
+
+    it('最大サイズ以上にはならない（幅1920px、高さ1080px）', () => {
+      useStreamStore.getState().addStream('https://www.youtube.com/watch?v=test1')
+      const streamId = useStreamStore.getState().streams[0].id
+
+      useStreamStore.getState().updateStreamSize(streamId, 3000, 2000)
+
+      const stream = useStreamStore.getState().streams[0]
+      expect(stream.width).toBe(1920)
+      expect(stream.height).toBe(1080)
+    })
+
+    it('存在しないストリームIDでは何も起きない', () => {
+      useStreamStore.getState().addStream('https://www.youtube.com/watch?v=test1')
+
+      useStreamStore.getState().updateStreamSize('non-existent-id', 800, 450)
+
+      const stream = useStreamStore.getState().streams[0]
+      expect(stream.width).toBeUndefined()
+      expect(stream.height).toBeUndefined()
+    })
+  })
 })

--- a/apps/frontend/src/stores/useStreamStore.ts
+++ b/apps/frontend/src/stores/useStreamStore.ts
@@ -14,11 +14,18 @@ export type Stream = {
   height?: number
 }
 
+// サイズ制限
+const MIN_WIDTH = 200
+const MIN_HEIGHT = 150
+const MAX_WIDTH = 1920
+const MAX_HEIGHT = 1080
+
 type StreamStore = {
   streams: Stream[]
   addStream: (url: string) => boolean
   removeStream: (id: string) => void
   updateStreamPosition: (id: string, deltaX: number, deltaY: number) => void
+  updateStreamSize: (id: string, width: number, height: number) => void
   applyAutoLayout: (containerWidth: number, containerHeight: number, gap?: number) => void
 }
 
@@ -54,6 +61,17 @@ export const useStreamStore = create<StreamStore>((set) => ({
     set(state => ({
       streams: state.streams.map(s =>
         s.id === id ? { ...s, x: s.x + deltaX, y: s.y + deltaY } : s
+      ),
+    }))
+  },
+
+  updateStreamSize: (id: string, width: number, height: number) => {
+    const clampedWidth = Math.min(Math.max(width, MIN_WIDTH), MAX_WIDTH)
+    const clampedHeight = Math.min(Math.max(height, MIN_HEIGHT), MAX_HEIGHT)
+
+    set(state => ({
+      streams: state.streams.map(s =>
+        s.id === id ? { ...s, width: clampedWidth, height: clampedHeight } : s
       ),
     }))
   },


### PR DESCRIPTION
## Summary
- 右下のリサイズハンドルでタイルサイズを変更可能に
- 最小サイズ: 200x150px、最大サイズ: 1920x1080px
- ドラッグ中・リサイズ中はポインターイベントを無効化

## 変更内容
- `useStreamStore`に`updateStreamSize`アクションを追加
- `DraggableTile`にリサイズハンドルUIを追加
- マウスイベントでリサイズを実装

## Test plan
- [x] リサイズハンドルが表示される
- [x] リサイズでサイズが変更される
- [x] 最小サイズ以下にならない
- [x] 最大サイズ以上にならない
- [x] 全139テストがパス
- [x] 型チェックパス

Closes #61