### PR TITLE
fix: TSビルドエラー修正（未使用パラメータ）

### DIFF
--- a/apps/backend/src/routes/index.ts
+++ b/apps/backend/src/routes/index.ts
@@ -5,8 +5,8 @@ import type { FastifyInstance } from 'fastify'
 // import { layoutRoutes } from './layouts.js'
 // import { streamRoutes } from './streams.js'
 
-export async function registerRoutes(app: FastifyInstance) {
-  // await app.register(authRoutes, { prefix: '/api/auth' })
-  // await app.register(layoutRoutes, { prefix: '/api/layouts' })
-  // await app.register(streamRoutes, { prefix: '/api/streams' })
+export async function registerRoutes(_app: FastifyInstance) {
+  // await _app.register(authRoutes, { prefix: '/api/auth' })
+  // await _app.register(layoutRoutes, { prefix: '/api/layouts' })
+  // await _app.register(streamRoutes, { prefix: '/api/streams' })
 }


### PR DESCRIPTION
deploy.ymlのDockerビルドで発生したTSエラーを修正。routes/index.tsの未使用パラメータ `app` を `_app` に変更。