### PR TITLE
fix: デプロイ時のpnpmバージョン二重指定を修正

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,8 +36,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - name: Install backend dependencies
         run: pnpm install --filter=backend --frozen-lockfile


### PR DESCRIPTION
## 概要

`pnpm/action-setup@v4` に `version: 10` を指定していたが、`package.json` の `packageManager: pnpm@10.30.3` と競合してデプロイが失敗していた。

## 変更点

- `deploy.yml` の `pnpm/action-setup` から `version: 10` を削除
- `package.json` の `packageManager` フィールドの値が自動で使われるようになる