### PR TITLE
fix: GitHub Actions SAにSecret Manager読み取り権限を追加

### DIFF
--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -43,3 +43,10 @@ resource "google_project_iam_member" "github_sa_user" {
   role    = "roles/iam.serviceAccountUser"
   member  = "serviceAccount:${google_service_account.github_actions.email}"
 }
+
+# GitHub Actions SA: Secret Manager読み取り権限（マイグレーション時にDATABASE_URLを取得するため）
+resource "google_project_iam_member" "github_secret" {
+  project = var.project_id
+  role    = "roles/secretmanager.secretAccessor"
+  member  = "serviceAccount:${google_service_account.github_actions.email}"
+}


### PR DESCRIPTION
## 概要

マイグレーションステップで `gcloud secrets versions access` を実行する際、GitHub Actions SAに `secretmanager.secretAccessor` 権限がなくてPERMISSION_DENIEDエラーが発生していた。

## 変更点

- `terraform/iam.tf` に `github_secret` リソースを追加
- `roles/secretmanager.secretAccessor` を `tamado-github-actions-sa` に付与済み（`terraform apply` 適用済み）