### PR TITLE
fix: Dockerfile.prod Stage 2にもprisma generateを追加

### DIFF
--- a/apps/backend/Dockerfile.prod
+++ b/apps/backend/Dockerfile.prod
@@ -30,6 +30,10 @@ COPY apps/backend/package.json ./apps/backend/
 
 RUN pnpm install --filter=backend --frozen-lockfile --prod
 
+COPY apps/backend/prisma ./apps/backend/prisma/
+COPY apps/backend/prisma.config.ts ./apps/backend/
+RUN cd /app/apps/backend && DATABASE_URL=postgresql://dummy:dummy@localhost/dummy pnpm exec prisma generate
+
 COPY --from=build /app/apps/backend/dist ./apps/backend/dist
 
 ENV NODE_ENV=production


### PR DESCRIPTION
multi-stage buildでStage 1のprisma generateで生成されたクライアントがStage 2のpnpm install --prodで消えてしまうため、Stage 2にもgenerateを追加。