### PR TITLE
fix: PrismaClientにdatasourceUrlを明示的に渡す（Prisma 7対応）

### DIFF
--- a/apps/backend/src/lib/prisma.ts
+++ b/apps/backend/src/lib/prisma.ts
@@ -1,3 +1,5 @@
 import { PrismaClient } from '@prisma/client'
 
-export const prisma = new PrismaClient()
+export const prisma = new PrismaClient({
+  datasourceUrl: process.env.DATABASE_URL,
+})


### PR DESCRIPTION
Prisma 7では new PrismaClient() を引数なしで呼ぶと PrismaClientInitializationError が発生する。DATABASE_URL を datasourceUrl として明示的に渡すことで解決。