### PR TITLE
fix: schema.prismaにDATABASE_URLを追加してPrismaClient初期化を修正

### DIFF
--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -4,6 +4,7 @@ generator client {
 
 datasource db {
   provider = "postgresql"
+  url      = env("DATABASE_URL")
 }
 
 model User {

--- a/apps/backend/src/lib/prisma.ts
+++ b/apps/backend/src/lib/prisma.ts
@@ -1,5 +1,3 @@
 import { PrismaClient } from '@prisma/client'
 
-export const prisma = new PrismaClient({
-  datasourceUrl: process.env.DATABASE_URL,
-})
+export const prisma = new PrismaClient()


### PR DESCRIPTION
Prisma 7でPrismaClientOptionsにdatasourceUrlが存在しないためTSエラー。schema.prismaのdatasourceにurl = env("DATABASE_URL")を戻すことで引数なしのnew PrismaClient()が正しく動作するよう修正。