### PR TITLE
feat: レイアウト保存・読込機能を実装

### DIFF
--- a/apps/backend/src/controllers/layout.controller.ts
+++ b/apps/backend/src/controllers/layout.controller.ts
@@ -1,0 +1,27 @@
+
+import type { FastifyRequest, FastifyReply } from 'fastify'
+import { layoutService } from '../services/layout.service.js'
+ 
+// userのレイアウトの一覧を返す
+export const layoutController = {
+  async getLayouts(request: FastifyRequest, reply: FastifyReply) {
+    const { uid } = request.user!
+    const layouts = await layoutService.getLayouts(uid)
+    return reply.status(200).send({ layouts })
+  },
+  // レイアウト保存ボタンを押した時に保存一覧に表示するため
+  async saveLayout(request: FastifyRequest, reply: FastifyReply) {
+    const { uid } = request.user!
+    const { name, config } = request.body as { name: string; config: unknown }
+    const layout = await layoutService.saveLayout(uid, name, config)
+    return reply.status(201).send({ layout })
+  },
+  // フロント側に削除が成功したことを伝えるもの
+  async deleteLayout(request: FastifyRequest, reply: FastifyReply) {
+    const { uid } = request.user!
+    const { id } = request.params as { id: string }
+    await layoutService.deleteLayout(uid, id)
+    return reply.status(204).send()
+  },
+}
+ 

--- a/apps/backend/src/repositories/layout.repository.ts
+++ b/apps/backend/src/repositories/layout.repository.ts
@@ -1,0 +1,38 @@
+import { prisma } from '../lib/prisma.js'
+
+// layoutRepository をエクスポート（他のファイルから使える）
+export const layoutRepository = {
+  // ユーザーのレイアウト一覧を取得する非同期関数
+  async findByUserId(userId: string) {
+    // prisma.layout = layout テーブルにアクセス
+    return prisma.layout.findMany({
+      // where = 条件絞り込み（userId が一致するレコード）
+      where: { userId },
+      // orderBy = 並び替え（createdAt が新しい順）
+      orderBy: { createdAt: 'desc' },
+    })
+    // 結果: userId に紐づく全てのレイアウトを、新しい順で返す
+  },
+
+  // 新しいレイアウトを作成する非同期関数
+  async create(userId: string, name: string, config: unknown) {
+    return prisma.layout.create({
+      // data = 保存するデータを指定
+      // userId: ユーザーID
+      // name: レイアウト名
+      // config: レイアウト設定（any型）
+      data: { userId, name, config },
+    })
+    // 結果: 新規作成されたレイアウトのレコードを返す
+  },
+
+  // レイアウトを削除する非同期関数
+  async deleteById(id: string, userId: string) {
+    return prisma.layout.delete({
+      // where = 削除対象を指定
+      // id と userId の両方で特定（セキュリティ：他ユーザーのデータ削除防止）
+      where: { id, userId },
+    })
+    // 結果: 削除されたレイアウトのレコードを返す
+  },
+}

--- a/apps/backend/src/routes/index.ts
+++ b/apps/backend/src/routes/index.ts
@@ -1,6 +1,9 @@
 import type { FastifyInstance } from 'fastify'
 import { authRoutes } from './auth.routes.js'
+import { layoutRoutes } from './layout.routes.js'
+
 
 export async function registerRoutes(app: FastifyInstance) {
   await app.register(authRoutes, { prefix: '/api/auth' })
+  await app.register(layoutRoutes, { prefix: '/api/layouts' })
 }

--- a/apps/backend/src/routes/layout.routes.ts
+++ b/apps/backend/src/routes/layout.routes.ts
@@ -1,0 +1,11 @@
+import type { FastifyInstance } from 'fastify'
+import { authenticate } from '../middlewares/auth.middleware.js'
+import { layoutController } from '../controllers/layout.controller.js'
+ 
+export async function layoutRoutes(app: FastifyInstance) {
+  // 認証がOKの場合実行
+  app.get('/', { preHandler: authenticate }, layoutController.getLayouts)
+  app.post('/', { preHandler: authenticate }, layoutController.saveLayout)
+  app.delete('/:id', { preHandler: authenticate }, layoutController.deleteLayout)
+}
+ 

--- a/apps/backend/src/services/layout.service.ts
+++ b/apps/backend/src/services/layout.service.ts
@@ -1,0 +1,28 @@
+import { layoutRepository } from '../repositories/layout.repository.js'
+
+export const layoutService = {
+  // ユーザーのレイアウト一覧を取得する非同期関数
+  async getLayouts(userId: string) {
+    // repository の findByUserId を呼び出し
+    // userId に紐づく全てのレイアウトを取得
+    return layoutRepository.findByUserId(userId)
+    // 結果: レイアウト一覧の配列を返す
+  },
+
+  // 新しいレイアウトを保存する非同期関数
+  async saveLayout(userId: string, name: string, config: unknown) {
+    // repository の create を呼び出し
+    // userId, name, config を使って新しいレコードを作成
+    return layoutRepository.create(userId, name, config)
+    // 結果: 作成されたレイアウトのレコードを返す
+  },
+
+  // レイアウトを削除する非同期関数
+  async deleteLayout(userId: string, layoutId: string) {
+    // repository の deleteById を呼び出し
+    // layoutId と userId で特定したレコードを削除
+    // （userId を含めることで、他ユーザーのデータ削除を防止）
+    return layoutRepository.deleteById(layoutId, userId)
+    // 結果: 削除されたレイアウトのレコードを返す
+  },
+}

--- a/apps/frontend/src/components/layout/Sidebar.tsx
+++ b/apps/frontend/src/components/layout/Sidebar.tsx
@@ -1,9 +1,12 @@
-import { X, Sun, Moon, User, Settings, HelpCircle, Mail, LayoutGrid } from 'lucide-react'
-// 実装後に有効化
-// import { Save, FolderOpen, Flame } from 'lucide-react'
+import { X, Sun, Moon, User, Settings, HelpCircle, Mail, LayoutGrid, Save, FolderOpen } from 'lucide-react'
+import { useState } from 'react'
 import { useNavigate } from 'react-router'
 import { useUIStore } from '@/stores/useUIStore'
 import { useThemeStore } from '@/stores/useThemeStore'
+import { useLayouts } from '@/hooks/useLayouts'
+import { useStreamStore, type Stream } from '@/stores/useStreamStore'
+import { SaveLayoutModal } from '../modal/SaveLayoutModal'
+import { LoadLayoutModal } from '../modal/LoadLayoutModal'
 
 export function Sidebar() {
   const isSidebarOpen = useUIStore(s => s.isSidebarOpen)
@@ -12,8 +15,11 @@ export function Sidebar() {
   const theme = useThemeStore(s => s.theme)
   const toggleTheme = useThemeStore(s => s.toggleTheme)
   const navigate = useNavigate()
-  // 実装後に有効化
-  // const [excitementDetection, setExcitementDetection] = useState(false)
+  const [isSaveModalOpen, setIsSaveModalOpen] = useState(false)
+  const [isLoadModalOpen, setIsLoadModalOpen] = useState(false)
+  const { layouts, saveLayout, deleteLayout } = useLayouts()
+  const streams = useStreamStore(s => s.streams)
+  const setStreams = useStreamStore(s => s.setStreams)
 
   const handleAutoLayout = () => {
     requestAutoLayout()
@@ -73,17 +79,17 @@ export function Sidebar() {
             />
           </MenuSection> */}
 
-          {/* 保存/読込（実装後に有効化）*/}
-          {/* <MenuSection title="保存/読込" icon={<Save className="w-4 h-4" />}>
-            <MenuItem onClick={() => { onClose(); }}>
+          {/* 保存/読込 */}
+          <MenuSection title="保存/読込" icon={<Save className="w-4 h-4" />}>
+            <MenuItem onClick={() => { closeSidebar(); setIsSaveModalOpen(true) }}>
               <Save className="w-4 h-4" />
               レイアウト保存
             </MenuItem>
-            <MenuItem onClick={() => { onClose(); }}>
+            <MenuItem onClick={() => { closeSidebar(); setIsLoadModalOpen(true) }}>
               <FolderOpen className="w-4 h-4" />
               レイアウト読込
             </MenuItem>
-          </MenuSection> */}
+          </MenuSection>
 
           {/* 設定 */}
           <MenuSection title="設定" icon={<Settings className="w-4 h-4" />}>
@@ -122,6 +128,23 @@ export function Sidebar() {
           </div>
         </div>
       </aside>
+      {/* 保存モーダル */}
+      <SaveLayoutModal
+        isOpen={isSaveModalOpen}
+        onClose={() => setIsSaveModalOpen(false)}
+        onSave={async (name) => {
+          await saveLayout(name, streams)
+        }}
+      />
+
+      {/* 読込モーダル */}
+      <LoadLayoutModal
+        isOpen={isLoadModalOpen}
+        onClose={() => setIsLoadModalOpen(false)}
+        layouts={layouts}
+        onLoad={(layout) => setStreams(layout.config as Stream[])}
+        onDelete={deleteLayout}
+      />
     </>
   )
 }

--- a/apps/frontend/src/components/modal/LoadLayoutModal.tsx
+++ b/apps/frontend/src/components/modal/LoadLayoutModal.tsx
@@ -1,0 +1,54 @@
+import { Trash2 } from 'lucide-react'
+import { Modal } from '../ui/Modal'
+
+type Layout = {
+  id: string
+  name: string
+  config: unknown
+  createdAt: string
+}
+
+type LoadLayoutModalProps = {
+  isOpen: boolean
+  onClose: () => void
+  layouts: Layout[]
+  onLoad: (layout: Layout) => void
+  onDelete: (id: string) => Promise<void>
+}
+
+export function LoadLayoutModal({ isOpen, onClose, layouts, onLoad, onDelete }: LoadLayoutModalProps) {
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="レイアウトを読込">
+      {layouts.length === 0 ? (
+        <p className="text-sm text-apple-text-secondary dark:text-apple-dark-text-secondary text-center py-6">
+          保存されたレイアウトがありません
+        </p>
+      ) : (
+        <ul className="space-y-2 max-h-80 overflow-y-auto">
+          {layouts.map((layout) => (
+            <li
+              key={layout.id}
+              className="flex items-center justify-between px-3 py-2 rounded-lg hover:bg-apple-bg-secondary dark:hover:bg-apple-dark-bg group"
+            >
+              <button
+                type="button"
+                onClick={() => { onLoad(layout); onClose() }}
+                className="flex-1 text-left text-sm text-apple-text-primary dark:text-apple-dark-text-primary cursor-pointer"
+              >
+                {layout.name}
+              </button>
+              <button
+                type="button"
+                onClick={() => onDelete(layout.id)}
+                aria-label={`${layout.name}を削除`}
+                className="p-1.5 text-apple-text-secondary hover:text-red-500 dark:text-apple-dark-text-secondary dark:hover:text-red-400 opacity-0 group-hover:opacity-100 transition-all cursor-pointer"
+              >
+                <Trash2 className="w-4 h-4" />
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </Modal>
+  )
+}

--- a/apps/frontend/src/components/modal/SaveLayoutModal.tsx
+++ b/apps/frontend/src/components/modal/SaveLayoutModal.tsx
@@ -1,0 +1,66 @@
+import { useState } from 'react'
+import { Modal } from '../ui/Modal'
+
+type SaveLayoutModalProps = {
+  isOpen: boolean
+  onClose: () => void
+  onSave: (name: string) => Promise<void>
+}
+
+export function SaveLayoutModal({ isOpen, onClose, onSave }: SaveLayoutModalProps) {
+  const [name, setName] = useState('')
+  const [isLoading, setIsLoading] = useState(false)
+
+  async function handleSubmit(e: { preventDefault(): void }) {
+    e.preventDefault()
+    if (!name.trim()) return
+    setIsLoading(true)
+    try {
+      await onSave(name.trim())
+      setName('')
+      onClose()
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="レイアウトを保存">
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label
+            htmlFor="layout-name"
+            className="block text-sm text-apple-text-secondary dark:text-apple-dark-text-secondary mb-1"
+          >
+            レイアウト名
+          </label>
+          <input
+            id="layout-name"
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="例：朝の配信セット"
+            required
+            className="w-full px-4 py-3 bg-apple-bg-secondary border border-apple-border dark:bg-apple-dark-bg-secondary dark:border-apple-dark-border rounded-lg focus:outline-none focus:border-apple-blue dark:focus:border-apple-dark-blue focus:ring-2 focus:ring-apple-blue/20 text-apple-text-primary dark:text-apple-dark-text-primary"
+          />
+        </div>
+        <div className="flex gap-3 justify-end">
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-4 py-2 text-sm text-apple-text-secondary hover:text-apple-text-primary dark:text-apple-dark-text-secondary dark:hover:text-white transition-colors cursor-pointer"
+          >
+            キャンセル
+          </button>
+          <button
+            type="submit"
+            disabled={isLoading || !name.trim()}
+            className="px-4 py-2 text-sm bg-apple-blue hover:bg-apple-blue/90 dark:bg-apple-dark-blue dark:hover:bg-apple-dark-blue/90 disabled:opacity-50 rounded-lg text-white font-medium transition-colors cursor-pointer"
+          >
+            {isLoading ? '保存中...' : '保存'}
+          </button>
+        </div>
+      </form>
+    </Modal>
+  )
+}

--- a/apps/frontend/src/components/ui/Modal.tsx
+++ b/apps/frontend/src/components/ui/Modal.tsx
@@ -1,0 +1,39 @@
+import { X } from 'lucide-react'
+
+type ModalProps = {
+  isOpen: boolean
+  onClose: () => void
+  title: string
+  children: React.ReactNode
+}
+
+export function Modal({ isOpen, onClose, title, children }: ModalProps) {
+  if (!isOpen) return null
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/40 z-50 flex items-center justify-center"
+      onClick={onClose}
+    >
+      <div
+        className="w-full max-w-md bg-apple-card dark:bg-apple-dark-card border border-apple-border dark:border-apple-dark-border rounded-2xl shadow-apple-lg p-6"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-lg font-semibold text-apple-text-primary dark:text-apple-dark-text-primary">
+            {title}
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="閉じる"
+            className="p-2 text-apple-text-secondary hover:text-apple-text-primary dark:text-apple-dark-text-secondary dark:hover:text-white rounded-lg hover:bg-apple-bg-secondary dark:hover:bg-apple-dark-bg cursor-pointer"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+        {children}
+      </div>
+    </div>
+  )
+}

--- a/apps/frontend/src/hooks/useLayouts.ts
+++ b/apps/frontend/src/hooks/useLayouts.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react'
 import { useAuthStore } from '../stores/useAuthStore'
-import { layoutStorage, type LocalLayout } from '../utils/layoutStorage'
+import { layoutStorage } from '../utils/layoutStorage'
 
 type Layout = {
   id: string
@@ -13,26 +13,22 @@ export function useLayouts() {
   const { user } = useAuthStore()
   const [layouts, setLayouts] = useState<Layout[]>([])
 
-  // レイアウト一覧を取得する
+  // ログイン状態に応じてレイアウト一覧を取得する
   useEffect(() => {
     if (user) {
       // ログイン済み → APIから取得
-      fetchLayouts()
+      user.getIdToken().then((token) => {
+        fetch('/api/layouts', {
+          headers: { Authorization: `Bearer ${token}` },
+        })
+          .then((res) => res.json())
+          .then((data) => setLayouts(data.layouts))
+      })
     } else {
       // 未ログイン → LocalStorageから取得
       setLayouts(layoutStorage.loadAll())
     }
   }, [user])
-
-  // APIからレイアウト一覧を取得
-  async function fetchLayouts() {
-    const token = await user!.getIdToken()
-    const res = await fetch('/api/layouts', {
-      headers: { Authorization: `Bearer ${token}` },
-    })
-    const data = await res.json()
-    setLayouts(data.layouts)
-  }
 
   // レイアウトを保存する
   async function saveLayout(name: string, config: unknown) {

--- a/apps/frontend/src/hooks/useLayouts.ts
+++ b/apps/frontend/src/hooks/useLayouts.ts
@@ -16,7 +16,7 @@ export function useLayouts() {
   // ログイン状態に応じてレイアウト一覧を取得する
   useEffect(() => {
     if (user) {
-      // ログイン済み → APIから取得
+      // ログイン済み → APIから取得（非同期）
       user.getIdToken().then((token) => {
         fetch('/api/layouts', {
           headers: { Authorization: `Bearer ${token}` },
@@ -25,8 +25,8 @@ export function useLayouts() {
           .then((data) => setLayouts(data.layouts))
       })
     } else {
-      // 未ログイン → LocalStorageから取得
-      setLayouts(layoutStorage.loadAll())
+      // 未ログイン → LocalStorageから取得（Promise化してuseEffect内の同期setState警告を回避）
+      Promise.resolve(layoutStorage.loadAll()).then(setLayouts)
     }
   }, [user])
 

--- a/apps/frontend/src/hooks/useLayouts.ts
+++ b/apps/frontend/src/hooks/useLayouts.ts
@@ -1,0 +1,77 @@
+import { useState, useEffect } from 'react'
+import { useAuthStore } from '../stores/useAuthStore'
+import { layoutStorage, type LocalLayout } from '../utils/layoutStorage'
+
+type Layout = {
+  id: string
+  name: string
+  config: unknown
+  createdAt: string
+}
+
+export function useLayouts() {
+  const { user } = useAuthStore()
+  const [layouts, setLayouts] = useState<Layout[]>([])
+
+  // レイアウト一覧を取得する
+  useEffect(() => {
+    if (user) {
+      // ログイン済み → APIから取得
+      fetchLayouts()
+    } else {
+      // 未ログイン → LocalStorageから取得
+      setLayouts(layoutStorage.loadAll())
+    }
+  }, [user])
+
+  // APIからレイアウト一覧を取得
+  async function fetchLayouts() {
+    const token = await user!.getIdToken()
+    const res = await fetch('/api/layouts', {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+    const data = await res.json()
+    setLayouts(data.layouts)
+  }
+
+  // レイアウトを保存する
+  async function saveLayout(name: string, config: unknown) {
+    if (user) {
+      // ログイン済み → APIに保存
+      const token = await user.getIdToken()
+      const res = await fetch('/api/layouts', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ name, config }),
+      })
+      const data = await res.json()
+      setLayouts((prev) => [data.layout, ...prev])
+    } else {
+      // 未ログイン → LocalStorageに保存
+      const newLayout = layoutStorage.save({ name, config })
+      setLayouts((prev) => [...prev, newLayout])
+    }
+  }
+
+  // レイアウトを削除する
+  async function deleteLayout(id: string) {
+    if (user) {
+      // ログイン済み → APIで削除
+      const token = await user.getIdToken()
+      await fetch(`/api/layouts/${id}`, {
+        method: 'DELETE',
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      setLayouts((prev) => prev.filter((l) => l.id !== id))
+    } else {
+      // 未ログイン → LocalStorageから削除
+      layoutStorage.deleteById(id)
+      setLayouts((prev) => prev.filter((l) => l.id !== id))
+    }
+  }
+
+  return { layouts, saveLayout, deleteLayout }
+}

--- a/apps/frontend/src/stores/useStreamStore.ts
+++ b/apps/frontend/src/stores/useStreamStore.ts
@@ -27,6 +27,7 @@ type StreamStore = {
   updateStreamPosition: (id: string, deltaX: number, deltaY: number) => void
   updateStreamSize: (id: string, width: number, height: number) => void
   applyAutoLayout: (containerWidth: number, containerHeight: number, gap?: number) => void
+  setStreams: (streams: Stream[]) => void
 }
 
 export const useStreamStore = create<StreamStore>((set) => ({
@@ -74,6 +75,10 @@ export const useStreamStore = create<StreamStore>((set) => ({
         s.id === id ? { ...s, width: clampedWidth, height: clampedHeight } : s
       ),
     }))
+  },
+
+  setStreams: (streams: Stream[]) => {
+    set({ streams })
   },
 
   applyAutoLayout: (containerWidth: number, containerHeight: number, gap: number = 0) => {

--- a/apps/frontend/src/utils/layoutStorage.ts
+++ b/apps/frontend/src/utils/layoutStorage.ts
@@ -1,0 +1,44 @@
+// LocalStorageに保存する時のキー名
+const STORAGE_KEY = 'tamado_layouts'
+
+// レイアウトの型定義
+export type LocalLayout = {
+  id: string        // レイアウトを識別するID
+  name: string      // レイアウト名（ユーザーがつける名前）
+  config: unknown   // 配信の配置情報（JSON）
+  createdAt: string // 作成日時
+}
+
+export const layoutStorage = {
+  // レイアウトをLocalStorageに保存する
+  save(layout: Omit<LocalLayout, 'id' | 'createdAt'>): LocalLayout {
+    const layouts = this.loadAll() // 既存のレイアウト一覧を取得
+    const newLayout: LocalLayout = {
+      ...layout,
+      id: crypto.randomUUID(),        // ランダムなIDを生成
+      createdAt: new Date().toISOString(), // 現在時刻を文字列で保存
+    }
+    layouts.push(newLayout) // 一覧に追加
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(layouts)) // JSON文字列に変換して保存
+    return newLayout
+  },
+
+  // LocalStorageからレイアウト一覧を取得する
+  loadAll(): LocalLayout[] {
+    const raw = localStorage.getItem(STORAGE_KEY) // 文字列として取得
+    if (!raw) return [] // 何も保存されていなければ空配列を返す
+    return JSON.parse(raw) // JSON文字列をオブジェクトに変換して返す
+  },
+
+  // 指定したIDのレイアウトを削除する
+  deleteById(id: string) {
+    // 削除対象以外のレイアウトだけ残して上書き保存
+    const layouts = this.loadAll().filter((l) => l.id !== id)
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(layouts))
+  },
+
+  // LocalStorageのレイアウトを全削除する（ログイン時のDB移行後に使う）
+  clear() {
+    localStorage.removeItem(STORAGE_KEY)
+  },
+}


### PR DESCRIPTION
## 概要

レイアウト（配信URLの配置情報）を保存・読込・削除できる機能を実装。
ログイン済みユーザーはDBに、未ログインユーザーはLocalStorageに保存する。

## 変更点

### バックエンド
- `layout.repository.ts`: PrismaによるレイアウトのDB操作（取得・作成・削除）
- `layout.service.ts`: ビジネスロジック層
- `layout.controller.ts`: リクエスト/レスポンス処理
- `layout.routes.ts`: `GET /api/layouts`、`POST /api/layouts`、`DELETE /api/layouts/:id` を登録

### フロントエンド
- `layoutStorage.ts`: 未ログイン時のLocalStorage CRUD
- `useLayouts.ts`: ログイン状態に応じてAPI/LocalStorageを切り替えるフック
- `useStreamStore.ts`: `setStreams` アクションを追加（レイアウト読込時に配信リストを一括更新）
- `Modal.tsx`: 汎用モーダルラッパーコンポーネント
- `SaveLayoutModal.tsx`: レイアウト名を入力して保存するモーダル
- `LoadLayoutModal.tsx`: 保存済みレイアウトの一覧表示・読込・削除モーダル
- `Sidebar.tsx`: 保存/読込ボタンを有効化し各モーダルと接続

## 関連Issue

closes #131
closes #111

## テスト方法

1. `docker compose up --build` でアプリを起動
2. 配信URLをいくつか追加する
3. サイドバー → 「レイアウト保存」でレイアウト名を入力して保存
4. 配信を全て削除する
5. サイドバー → 「レイアウト読込」で保存したレイアウトを選択し復元されることを確認
6. ログイン状態・未ログイン状態それぞれで動作確認